### PR TITLE
Devop 52 upgrade output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,4 +75,4 @@ outputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://epsyhealth/action-context"

--- a/action.yml
+++ b/action.yml
@@ -75,4 +75,4 @@ outputs:
 
 runs:
   using: "docker"
-  image: "docker://epsyhealth/action-context"
+  image: "Dockerfile"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 actions_toolkit==0.1.15
 semver==2.13.0
 toml==0.10.2
+easydict==1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,3 @@
-actions-toolkit==0.1.15; python_version >= "3.6"
-certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-cffi==1.15.1; python_version >= "3.6"
-charset-normalizer==2.0.12; python_full_version >= "3.6.0" and python_version >= "3.6"
-deprecated==1.2.13; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-easydict==1.9
-idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-pygithub==1.55; python_version >= "3.6"
-pyjwt==2.3.0; python_version >= "3.6"
-pynacl==1.5.0; python_version >= "3.6"
-requests==2.27.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-semver==2.13.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-toml==0.10.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
-urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
-wrapt==1.13.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+actions_toolkit==0.1.15
+semver==2.13.0
+toml==0.10.2


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/